### PR TITLE
Mark Dust3d as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
This application relies on an outdated runtime that was marked as end-of-life (EOL) five years ago.

https://github.com/flathub/org.dust3d.dust3d/issues/3